### PR TITLE
feat: add mongo resource to show on snack

### DIFF
--- a/quest.yml
+++ b/quest.yml
@@ -25,3 +25,5 @@ level: intermediate
 type: custom
 duration: 1.5
 repository: null
+resources:
+  - name: mongo


### PR DESCRIPTION
This won't run the generic step but will show mongo on snack's sidebar.

Engine PR: https://github.com/trywilco/wilco-engine/pull/2208